### PR TITLE
Handle strikes and spares

### DIFF
--- a/src/score.rs
+++ b/src/score.rs
@@ -4,23 +4,29 @@ use crate::Rolls;
 mod unit_tests;
 
 pub fn score(rolls: &Rolls) -> u16 {
-    let mut score = 0;
-    let mut prev_score = 0;
-    let mut is_prev_spare = false;
-    for roll_score in rolls.0.iter().map(|&v| u16::from(v)).collect::<Vec<u16>>() {
-        score += roll_score;
-        if is_prev_spare {
-            score += roll_score;
-        }
-
-        if is_spare(roll_score, prev_score) {
-            is_prev_spare = true;
-        }
-        prev_score = roll_score;
-    }
-    score
+    foo(rolls.0.iter(), 1)
 }
 
-fn is_spare(v1: u16, v2: u16) -> bool {
-    v1 + v2 == 10
+// variable-width fold
+// Item is an associated type
+fn foo<'a>(mut rolls: impl Iterator<Item=&'a u8> + Clone, frame_number: usize) -> u16 {
+    // base case:
+    if frame_number > 10 {
+        return 0;
+    }
+
+    // stuff!
+    // by_ref = by_ref_mut
+    // helps us keep ownership by giving exclusive unique access:
+    // unique access vs ownership!!!
+    let frame_score = rolls.by_ref().take(2).sum::<u8>();
+    // take drops the borrow here.
+    let mut bonus = 0;
+    if frame_score == 10 {
+        bonus = rolls.clone().take(1).sum::<u8>();
+    }
+
+    // recusive case - tail recursion
+    // rolls still owns the data
+    u16::from(frame_score + bonus) + foo(rolls, frame_number + 1)
 }

--- a/src/score.rs
+++ b/src/score.rs
@@ -4,7 +4,23 @@ use crate::Rolls;
 mod unit_tests;
 
 pub fn score(rolls: &Rolls) -> u16 {
-    rolls.0.iter()
-           .map(|&v| u16::from(v))
-           .sum()
+    let mut score = 0;
+    let mut prev_score = 0;
+    let mut is_prev_spare = false;
+    for roll_score in rolls.0.iter().map(|&v| u16::from(v)).collect::<Vec<u16>>() {
+        score += roll_score;
+        if is_prev_spare {
+            score += roll_score;
+        }
+
+        if is_spare(roll_score, prev_score) {
+            is_prev_spare = true;
+        }
+        prev_score = roll_score;
+    }
+    score
+}
+
+fn is_spare(v1: u16, v2: u16) -> bool {
+    v1 + v2 == 10
 }

--- a/src/score.rs
+++ b/src/score.rs
@@ -9,22 +9,43 @@ pub fn score(rolls: &Rolls) -> u16 {
 
 // variable-width fold
 // Item is an associated type
-fn foo<'a>(mut rolls: impl Iterator<Item=&'a u8> + Clone, frame_number: usize) -> u16 {
+fn foo<'a>(mut rolls: impl Iterator<Item = &'a u8> + Clone, frame_number: usize) -> u16 {
     // base case:
     if frame_number > 10 {
         return 0;
     }
 
-    // stuff!
-    // by_ref = by_ref_mut
-    // helps us keep ownership by giving exclusive unique access:
-    // unique access vs ownership!!!
-    let frame_score = rolls.by_ref().take(2).sum::<u8>();
-    // take drops the borrow here.
-    let mut bonus = 0;
-    if frame_score == 10 {
-        bonus = rolls.clone().take(1).sum::<u8>();
-    }
+    let mut frame_score = 0;
+    let roll_count = rolls
+        // by_ref ("by_ref_mut") helps us keep ownership by giving
+        // exclusive "unique access" via mutable borrowing -
+        // (different than transferring ownership)
+        .by_ref()
+        .enumerate()
+        // double ref here with take_while: Because the closure passed
+        // to take_while() takes a reference, and many iterators
+        // iterate over references, this leads to a possibly confusing
+        // situation, where the type of the closure is a double
+        // reference:
+        .take_while(|&(i, &roll)| {
+            // This is our "predicate" - a single variable function that returns a bool
+            frame_score += roll;
+            // take_while will throw away the item if predicate returns false!!!
+            i == 0 && roll < 10
+        }).count()
+        // +1 accounts for the last take_while iteration, which is
+        // dropped when the predicate returns false.
+        + 1;
+    // take_while drops the borrow here.
+
+    let bonus = rolls
+        .clone()
+        .take(match (roll_count, frame_score) {
+            (1, 10) => 2,
+            (2, 10) => 1,
+            _ => 0,
+        })
+        .sum::<u8>();
 
     // recusive case - tail recursion
     // rolls still owns the data

--- a/src/score/unit_tests.rs
+++ b/src/score/unit_tests.rs
@@ -126,3 +126,31 @@ fn score_all_spares_returns_() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn score_strike_then_open() -> Result<()> {
+    // given a roll with a strike
+    let rolls = Rolls::new(&[10, 2, 2])?;
+
+    // when `score()` is calculated
+    let res = score(&rolls);
+
+    // then the result should be 12
+    assert_eq!(18, res);
+
+    Ok(())
+}
+
+#[test]
+fn score_all_strikes() -> Result<()> {
+    // given a roll with a strike
+    let rolls = Rolls::new(&[10, 12])?;
+
+    // when `score()` is calculated
+    let res = score(&rolls);
+
+    // then the result should be 12
+    assert_eq!(300, res);
+
+    Ok(())
+}

--- a/src/score/unit_tests.rs
+++ b/src/score/unit_tests.rs
@@ -58,15 +58,28 @@ fn score_all_gutterballs_returns_0() -> Result<()> {
 
 #[test]
 fn score_one_ball_returns_1() -> Result<()> {
-    // given an empty `Rolls`
+    // given a single roll
     let rolls = Rolls::new(&[1])?;
 
     // when `score()` is calculated
     let res = score(&rolls);
 
-    // then the result should be 0
+    // then the result should be 1
     assert_eq!(1, res);
 
     Ok(())
 }
 
+#[test]
+fn score_spare_score_1_returns_12() -> Result<()> {
+    // given a roll with a strike
+    let rolls = Rolls::new(&[5, 5, 1])?;
+
+    // when `score()` is calculated
+    let res = score(&rolls);
+
+    // then the result should be 12
+    assert_eq!(12, res);
+
+    Ok(())
+}

--- a/src/score/unit_tests.rs
+++ b/src/score/unit_tests.rs
@@ -71,6 +71,20 @@ fn score_one_ball_returns_1() -> Result<()> {
 }
 
 #[test]
+fn score_all_one_balls_returns_20() -> Result<()> {
+    // given a single roll
+    let rolls = Rolls::new(&[1; 20])?;
+
+    // when `score()` is calculated
+    let res = score(&rolls);
+
+    // then the result should be 1
+    assert_eq!(20, res);
+
+    Ok(())
+}
+
+#[test]
 fn score_spare_score_1_returns_12() -> Result<()> {
     // given a roll with a strike
     let rolls = Rolls::new(&[5, 5, 1])?;
@@ -80,6 +94,35 @@ fn score_spare_score_1_returns_12() -> Result<()> {
 
     // then the result should be 12
     assert_eq!(12, res);
+
+    Ok(())
+}
+
+
+#[test]
+fn score_open_then_spare_then_1_returns_14() -> Result<()> {
+    // given a roll with a strike
+    let rolls = Rolls::new(&[3, 5, 5, 1])?;
+
+    // when `score()` is calculated
+    let res = score(&rolls);
+
+    // then the result should be 12
+    assert_eq!(14, res);
+
+    Ok(())
+}
+
+#[test]
+fn score_all_spares_returns_() -> Result<()> {
+    // given a roll with a strike
+    let rolls = Rolls::new(&[5; 21])?;
+
+    // when `score()` is calculated
+    let res = score(&rolls);
+
+    // then the result should be 12
+    assert_eq!(150, res);
 
     Ok(())
 }


### PR DESCRIPTION
This PR implements handling of spares and strikes using a variable width fold, via recursion :tada: 